### PR TITLE
basic form styling added

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,0 +1,41 @@
+.form {
+  // align-items: center;
+  // padding-left: 150px;
+  justify-content: center;
+}
+
+.form-title {
+  // margin: 30px;
+  font-family: ll-unica77, “Helvetica Neue”, Helvetica, Arial, sans-serif;
+  font-size: 40px;
+  color: rgb(84, 83, 83);
+  padding-top: 20px;
+  justify-content: left;
+}
+
+.form-inputs{
+  margin-top: 20px;
+  margin-bottom: 20px;
+  background-color: rgb(222, 223, 229);
+  font-family: Helvetica, Arial, sans-serif;
+  max-width: 600px;
+  padding: 25px;
+  border-radius: 5px;
+  justify-content: center;
+}
+
+.form-actions {
+  margin-top: 40px;
+  background-color: black;
+  color: white;
+}
+
+.btn:hover {
+  background-color: white;
+}
+
+.form-bottom {
+  margin: 4px;
+  color: grey;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -4,3 +4,4 @@
 @import "form_legend_clear";
 @import "navbar";
 @import "button";
+@import "form";

--- a/app/views/suppliers/new.html.erb
+++ b/app/views/suppliers/new.html.erb
@@ -1,11 +1,11 @@
-<div class="container">
+<div class="container form">
   <h1>Create a new supplier</h1>
-  <div>
+  <div class="form-inputs">
     <%= simple_form_for(@supplier) do |f| %>
       <%= f.input :name %>
       <%= f.input :address %>
       <%= f.input :email %>
-      <%= f.submit "Submit", class: "" %>
+      <%= f.submit "Submit", class: "btn form-actions" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
# Description

Basic form styling pushed out for creating new suppliers - note partial set up so can duplicate across off for other forms

<img width="1440" alt="Screenshot 2022-11-24 at 11 13 16 AM" src="https://user-images.githubusercontent.com/108777684/203685917-76186d3f-cd1d-4a43-8dda-cf978804ff1a.png">



Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [x] local server
- [ ] heroku
