### PR TITLE
Templates link for individual supplier

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,16 +4,48 @@ class OrdersController < ApplicationController
 
   # http://localhost:3000/orders?status=template
   def index
+
     if params[:supplier_id].present?
-      @orders = Order.where(supplier_id: params[:user_id])
+
+      # suppliers/:id/orders?status=template
+      if params[:status] == "template"
+      @orders = Order.where(supplier_id: params[:supplier_id]).where(status: "template")
+
+      # suppliers/:id/orders?status=pending
+      elsif params[:status] == "pending"
+        @orders = Order.where(supplier_id: params[:supplier_id]).where(status: "pending")
+
+        # suppliers/:id/orders?status=sent
+      elsif params[:status] == "sent"
+        @orders = Order.where(supplier_id: params[:supplier_id]).where(status: "sent")
+
+        # suppliers/:id/orders?status=delivered
+      elsif params[:status] == "delivered"
+        @orders = Order.where(supplier_id: params[:supplier_id]).where(status: "delivered")
+
+        # suppliers/:id/orders
+      else
+        @orders = Order.where(supplier_id: params[:supplier_id])
+      # raise
+      # if Order.where(supplier_id: params[:user_id]).where(status: "template")
+    end
+
     elsif params[:status] == "template"
       @orders = Order.where(status: "template")
+
+      # /orders?status=pending
     elsif params[:status] == "pending"
       @orders = Order.where(status: "pending")
+
+      # /orders?status=sent
     elsif params[:status] == "sent"
       @orders = Order.where(status: "sent")
+
+      # /orders?status=delivered
     elsif params[:status] == "delivered"
       @orders = Order.where(status: "delivered")
+
+     # /orders
     else
       @orders = Order.all
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,7 @@
 class OrdersController < ApplicationController
   before_action :set_supplier, only: %i[new create]
   before_action :set_user, only: %i[new create]
+  attr_reader :id
 
   # http://localhost:3000/orders?status=template
   def index

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,9 +1,72 @@
 <div class="container my-4">
   <div class="row justify-content-center">
+
+  </div>
+
+
+<%if params[:supplier_id].present?%>
+    <div class="col-lg-8 d-flex justify-content-center">
+      <h1><strong> My Orders with <%= Supplier.find(params[:supplier_id]).name %></strong></h1> <br>
+    </div>
+
+
+      <div class="wrapper d-flex justify-content-center">
+      <div><%= link_to "All Orders", "/orders", class: "btn btn-ghost mx-2" %></div>
+      <div>   <%= link_to "Pending Orders", "/:id/orders?status=pending", class: "btn btn-ghost mx-2" %></div>
+      <div><%= link_to "Sent Orders", "/orders?status=sent", class: "btn btn-ghost mx-2" %></div>
+      <div>   <%= link_to "Delivered Orders", "/orders?status=delivered", class: "btn btn-ghost mx-2" %></div>
+    </div>
+
+      <div class="row justify-content-center my-4">
+        <div class="col-lg-8">
+          <% @orders.each_with_index do |order, index| %>
+            <% supplier_id = order.supplier_id %>
+            <% order_id = order.id %>
+
+
+          <%#  Accordion  %>
+            <div class="accordion accordion-flush" id="accordionOrder">
+              <%# Accordion 1  %>
+              <div class="accordion-item">
+                <h2 class="accordion-header" id="flush-heading">
+                  <button class="accordion-button collapsed" id="accordion-button-order" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse<%= index + 1 %>" aria-expanded="false" aria-controls="flush-collapse<%= index + 1 %>">
+                    <div class="accordion-order">
+                      <div class="accordion-order-info">
+                        <strong><%= Supplier.find(supplier_id).name %></strong><br>
+                        <%= order.delivery_date %>
+                      </div>
+                      <a class="accordion-order-btn"><%= order.status %></a>
+                    </div>
+                  </button>
+                </h2>
+                <div id="flush-collapse<%= index + 1 %>" class="accordion-collapse collapse" aria-labelledby="flush-heading" data-bs-parent="#accordionOrder">
+                  <div class="accordion-body">
+                    <div style="text-align: left">
+                      <% OrderDetail.where(order_id: order_id).each do |order_detail|%>
+                        <% product_id = order_detail.product_id %>
+                        <%= Product.find(product_id).name %><br>
+                      <% end %>
+                    </div>
+                      <%= link_to "View Order", order_path(order), class: "btn btn-ghost" %>
+                  </div>
+                </div>
+              </div>
+            <%# Accordion 2 %>
+            <%# Accordion 3 %>
+            <%# end of last accordion %>
+            <% end %>
+          </div>
+        <%# End of Accordion %>
+        </div>
+      </div>
+
+    </div>
+
+<%else%>
     <div class="col-lg-8 d-flex justify-content-center">
       <h1><strong> My Orders </strong></h1> <br>
     </div>
-  </div>
+
   <div class="wrapper d-flex justify-content-center">
   <div><%= link_to "All Orders", "/orders", class: "btn btn-ghost mx-2" %></div>
   <div>   <%= link_to "Pending Orders", "/orders?status=pending", class: "btn btn-ghost mx-2" %></div>
@@ -55,3 +118,5 @@
   </div>
 
 </div>
+
+<%end%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -5,15 +5,69 @@
 
 
 <%if params[:supplier_id].present?%>
+  <%if params[:supplier_id].present?%>
+
+     <div class="col-lg-8 d-flex justify-content-center">
+      <h1><strong> My Templates with <%= Supplier.find(params[:supplier_id]).name %></strong></h1> <br>
+    </div>
+
+    </div>
+
+      <div class="row justify-content-center my-4">
+        <div class="col-lg-8">
+          <% @orders.each_with_index do |order, index| %>
+            <% supplier_id = order.supplier_id %>
+            <% order_id = order.id %>
+
+
+          <%#  Accordion  %>
+            <div class="accordion accordion-flush" id="accordionOrder">
+              <%# Accordion 1  %>
+              <div class="accordion-item">
+                <h2 class="accordion-header" id="flush-heading">
+                  <button class="accordion-button collapsed" id="accordion-button-order" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse<%= index + 1 %>" aria-expanded="false" aria-controls="flush-collapse<%= index + 1 %>">
+                    <div class="accordion-order">
+                      <div class="accordion-order-info">
+                        <strong><%= Supplier.find(supplier_id).name %></strong><br>
+                        <%= order.delivery_date %>
+                      </div>
+                      <a class="accordion-order-btn"><%= order.status %></a>
+                    </div>
+                  </button>
+                </h2>
+                <div id="flush-collapse<%= index + 1 %>" class="accordion-collapse collapse" aria-labelledby="flush-heading" data-bs-parent="#accordionOrder">
+                  <div class="accordion-body">
+                    <div style="text-align: left">
+                      <% OrderDetail.where(order_id: order_id).each do |order_detail|%>
+                        <% product_id = order_detail.product_id %>
+                        <%= Product.find(product_id).name %><br>
+                      <% end %>
+                    </div>
+                      <%= link_to "View Order", order_path(order), class: "btn btn-ghost" %>
+                  </div>
+                </div>
+              </div>
+            <%# Accordion 2 %>
+            <%# Accordion 3 %>
+            <%# end of last accordion %>
+            <% end %>
+          </div>
+        <%# End of Accordion %>
+        </div>
+      </div>
+
+    </div>
+  <%else%>
+
     <div class="col-lg-8 d-flex justify-content-center">
       <h1><strong> My Orders with <%= Supplier.find(params[:supplier_id]).name %></strong></h1> <br>
     </div>
 
 
       <div class="wrapper d-flex justify-content-center">
-      <div><%= link_to "All Orders", "/orders", class: "btn btn-ghost mx-2" %></div>
-      <div>   <%= link_to "Pending Orders", "/:id/orders?status=pending", class: "btn btn-ghost mx-2" %></div>
-      <div><%= link_to "Sent Orders", "/orders?status=sent", class: "btn btn-ghost mx-2" %></div>
+      <div><%= link_to "All Orders", "../suppliers/:id/orders", class: "btn btn-ghost mx-2" %></div>
+      <div>   <%= link_to "Pending Orders", "/suppliers/:id/orders?status=pending", class: "btn btn-ghost mx-2" %></div>
+      <div><%= link_to "Sent Orders", ":id/orders?status=sent", class: "btn btn-ghost mx-2" %></div>
       <div>   <%= link_to "Delivered Orders", "/orders?status=delivered", class: "btn btn-ghost mx-2" %></div>
     </div>
 
@@ -61,7 +115,7 @@
       </div>
 
     </div>
-
+  <%end%>
 <%else%>
     <div class="col-lg-8 d-flex justify-content-center">
       <h1><strong> My Orders </strong></h1> <br>

--- a/app/views/suppliers/show.html.erb
+++ b/app/views/suppliers/show.html.erb
@@ -6,4 +6,8 @@
     <li><%= @supplier.email %> </li>
   </div>
 
+<%@supplier.id %>
+<div><%= link_to "All Orders", "../#{@supplier.id}/orders", class: "btn btn-ghost mx-2" %></div>
+  <%# <div><%= link_to "All Orders", "../suppliers/@supplier.id/orders", class: "btn btn-ghost mx-2"</div> %> %>
+
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ puts "Database cleaned"
 puts "Populating supplier seeds"
 puts "Database cleaned"
 
-no_of_orders = 15
+no_of_orders = 50
 
 puts "Populating supplier seeds"
 10.times do


### PR DESCRIPTION
I have created a page that shows the list of templates for each supplier:
- http://127.0.0.1:3000/suppliers/:supplier_id/orders?status=pending
- http://localhost:3000/suppliers/:supplier_id/orders?status=pending

I am still working on the rest of the routes for pending/ delivered/ sent - which I will complete in a later pull request.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [X] local server
- [ ] heroku
