### PR TITLE
Added dropdown for order status and made btn style consistent

### DIFF
--- a/app/assets/stylesheets/components/_dropdown.scss
+++ b/app/assets/stylesheets/components/_dropdown.scss
@@ -1,0 +1,5 @@
+.dropdown-meunu-li {
+  text-decoration: none;
+  color: black;
+  justify-content: left;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -7,3 +7,5 @@
 @import "button";
 @import "form";
 @import "push-btn";
+@import "view-btn";
+@import "dropdown";

--- a/app/assets/stylesheets/components/_push-btn.scss
+++ b/app/assets/stylesheets/components/_push-btn.scss
@@ -23,3 +23,22 @@
 .push-btn:hover {
   // color: rgb(214, 214, 214);
 }
+
+.push-btn-small {
+  background-color: rgb(186, 186, 186);
+  box-shadow: 4px 5px black;
+  border-radius: 15px;
+  border-width: 5px;
+  border: black;
+  color: black;
+  padding: 12px 28px;
+  text-align: center;
+  text-decoration: none;
+  align-items: center;
+  border: solid #000;
+  border-width: 2px 2px;
+  font-size: 16px;
+  position: absolute;
+  margin: 8px;
+  font-size: 14px;
+}

--- a/app/assets/stylesheets/components/_view-btn.scss
+++ b/app/assets/stylesheets/components/_view-btn.scss
@@ -1,0 +1,17 @@
+.view-btn {
+  border-radius: 15px;
+  border-width: 5px;
+  border: black;
+  color: black;
+  padding: 12px 28px;
+  display: flex;
+  text-decoration: none;
+  justify-content: center;
+  align-items: center;
+  border: solid #000;
+  border-width: 2px 2px;
+  font-size: 16px;
+  position: relative;
+  height: 40px;
+  width: 120px;
+}

--- a/app/assets/stylesheets/pages/_orders.scss
+++ b/app/assets/stylesheets/pages/_orders.scss
@@ -87,6 +87,7 @@
     :active {
       transform: translateY(2px);
     }
+  }
 
   .add-products:active{
     bottom: -2px;
@@ -106,15 +107,6 @@
 }
 
 
-// .add-products {
-//   background-color: black;
-//   color: black;
-
-//   :hover {
-//     color: black;
-//   }
-// }
-
 .line-order {
   line-height: 24px;
 }
@@ -126,10 +118,6 @@
   width: 100%;
   height: 200px;
   border-collapse: collapse;
-  // border-top: grey;
-  // border-bottom: grey;
-//   border-spacing: 0 2px;
-//   border-collapse: separate;
 }
 
 .table-order thead {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <%= render "shared/navbar2" %>
     <%= yield %>
 
-
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/views/orders/_order_mark_delivered.html.erb
+++ b/app/views/orders/_order_mark_delivered.html.erb
@@ -1,6 +1,6 @@
-  <div class="col-6">
+  <div class="col-12">
     <%= simple_form_for @order, url: order_path(@order) do |f| %>
       <%= f.hidden_field :status, :value => "delivered" %>
-      <%= f.submit "Mark as Delivered", class: "btn btn-ghost btn-order-mark", data: {turbo_confirm: "All items were delivered for this order?"}%>
+      <%= f.submit "Mark as Delivered", class: "push-btn-small", data: {turbo_confirm: "All items were delivered for this order?"}%>
     <% end %>
   </div>

--- a/app/views/orders/_order_show.html.erb
+++ b/app/views/orders/_order_show.html.erb
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-12">
       <div>
-        <a class="accordion-order-btn"><%= @order.status %></a>
+        <a class="view-btn"><%= @order.status %></a>
       </div>
       <div class="line-order my-4">
         <span><strong>Order <%=@order.id%> - <%= Supplier.find(@order.supplier_id).name %></strong></span><br/>

--- a/app/views/orders/_order_status_dropdown.html.erb
+++ b/app/views/orders/_order_status_dropdown.html.erb
@@ -1,0 +1,11 @@
+  <div class="dropdown mt-3 d-flex justify-content-end">
+    <button class="btn push-btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Order Status
+    </button>
+    <ul class="dropdown-menu">
+      <li><%= link_to "All", "/orders", class: "dropdown-item dropdown-meunu-li" %></li>
+      <li><%= link_to "Pending", "/orders?status=pending", class: "dropdown-item dropdown-meunu-li" %></li>
+      <li><%= link_to "Sent", "/orders?status=sent", class: "dropdown-item dropdown-meunu-li" %></li>
+      <li><%= link_to "Delivered", "/orders?status=delivered", class: "dropdown-item dropdown-meunu-li" %></li>
+    </ul>
+  </div>

--- a/app/views/orders/_order_status_dropdown_supplier.html.erb
+++ b/app/views/orders/_order_status_dropdown_supplier.html.erb
@@ -1,0 +1,11 @@
+  <div class="dropdown mt-3 d-flex justify-content-end">
+    <button class="btn push-btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Order Status
+    </button>
+    <ul class="dropdown-menu">
+      <li><%= link_to "All", supplier_orders_path(params[:supplier_id]), class: "dropdown-item dropdown-meunu-li" %></li>
+      <li><%= link_to "Pending Orders", supplier_orders_path(params[:supplier_id], status: "pending"), class: "dropdown-item dropdown-meunu-li" %></li>
+      <li><%= link_to "Sent Orders", supplier_orders_path(params[:supplier_id], status: "sent"), class: "dropdown-item dropdown-meunu-li" %></li>
+      <li><%= link_to "Delivered Orders", supplier_orders_path(params[:supplier_id], status: "delivered"), class: "dropdown-item dropdown-meunu-li" %></li>
+    </ul>
+  </div>

--- a/app/views/orders/_order_template_details.html.erb
+++ b/app/views/orders/_order_template_details.html.erb
@@ -1,19 +1,18 @@
 <% supplier_id = order.supplier_id %>
 <% order_id = order.id %>
 
-
 <%#  Accordion  %>
 <div class="accordion accordion-flush" id="accordionOrder">
   <%# Accordion 1  %>
   <div class="accordion-item">
     <h2 class="accordion-header" id="flush-heading">
-      <button class="accordion-button collapsed" id="accordion-button-order" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse<%= index + 1 %>" aria-expanded="false" aria-controls="flush-collapse<%= index + 1 %>">
-        <div class="accordion-order">
+      <button class="accordion-button collapsed px-0" id="accordion-button-order" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse<%= index + 1 %>" aria-expanded="false" aria-controls="flush-collapse<%= index + 1 %>">
+        <div class="accordion-order" style="padding-right: 5px">
           <div class="accordion-order-info">
             <strong><%= Supplier.find(supplier_id).name %></strong><br>
-              Arriving on <%= order.delivery_date %>
+              <%= order.delivery_date %>
           </div>
-          <a class="accordion-order-btn"><%= order.status %></a>
+          <a class="view-btn"><%= order.status %></a>
         </div>
       </button>
     </h2>
@@ -32,7 +31,7 @@
           <% else %>
             <% path = order_path(order) %>
           <% end%>
-          <%= link_to "View Order", path, class: "btn btn-ghost" %>
+          <%= link_to "View Order >", path, class: "stretched-link" %>
       </div>
     </div>
   </div>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,63 +1,49 @@
-<div class="container my-4">
-  <div class="row justify-content-center">
+<div class="container col-11 my-4 mx-1">
 
-  </div>
-
-
-<%if params[:supplier_id].present?%>
-  <%if params[:status] == "template"%>
-  <%else%>
-
-    <div class="col-lg-8 d-flex justify-content-center">
-      <h1><strong> My Orders with <%= Supplier.find(params[:supplier_id]).name %></strong></h1> <br>
-    </div>
-    <br>
-
-    <div class="wrapper d-flex justify-content-center">
-        <div><%= link_to "All Orders", supplier_orders_path(params[:supplier_id]), class: "push-btn" %></div>
-        <div><%= link_to "Pending Orders", supplier_orders_path(params[:supplier_id], status: "pending"), class: "push-btn" %></div>
-        <div><%= link_to "Sent Orders", supplier_orders_path(params[:supplier_id], status: "sent"), class: "push-btn" %></div>
-        <div><%= link_to "Delivered Orders", supplier_orders_path(params[:supplier_id], status: "delivered"), class: "push-btn" %></div>
-    </div>
-
+  <%# for suppliers/:id/orders %>
+  <%if params[:supplier_id].present?%>
+    <%if params[:status] == "template"%>
+    <%else%>
+      <div class="col-l2 d-flex justify-content-center px-2">
+        <h1><strong>My Orders with <%= Supplier.find(params[:supplier_id]).name %></strong></h1> <br>
+      </div><br>
+    <%# order status dropdown  %>
+    <%= render "order_status_dropdown_supplier"%>
+    <%# individual order accordion  %>
       <div class="row justify-content-center my-4">
-        <div class="col-lg-8">
+        <div class="col-12">
           <% @orders.each_with_index do |order, index| %>
               <%= render "order_template_details", order: order, index: index %>
             <% end %>
-          </div>
-        <%# End of Accordion %>
         </div>
       </div>
+        <%# End of Accordion %>
+      <%# </div> %>
+  <%# to enable dropdown bootstrap %>
+      <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
+    <%end%>
 
-    </div>
-  <%end%>
-<%else%>
-    <div class="col-lg-8 d-flex justify-content-center">
+  <%# for /orders without supplier id%>
+  <%else%>
+    <div class="col-12 d-flex justify-content-center">
       <h1><strong> My Orders </strong></h1> <br>
     </div>
-    <br>
-
-  <div class="wrapper d-flex justify-content-center">
-  <div><%= link_to "All Orders", "/orders", class: "push-btn" %></div>
-  <div><%= link_to "Pending Orders", "/orders?status=pending", class: "push-btn" %></div>
-  <div><%= link_to "Sent Orders", "/orders?status=sent", class: "push-btn" %></div>
-  <div><%= link_to "Delivered Orders", "/orders?status=delivered", class: "push-btn" %></div>
-</div>
-
-  <div class="row justify-content-center my-4">
-    <div class="col-lg-8">
-      <% @orders.each_with_index do |order, index| %>
-        <%= render "order_template_details", order: order, index: index %>
-       <% end %>
-     </div>
-    <%# End of Accordion %>
+    <%# order status dropdown  %>
+    <%= render "order_status_dropdown"%>
+    <%# individual order accordion  %>
+    <div class="row justify-content-center my-4">
+      <div class="col-12">
+        <% @orders.each_with_index do |order, index| %>
+          <%= render "order_template_details", order: order, index: index %>
+        <% end %>
+      </div>
+      <%# </div> %>
+    <%# </div> %>
     </div>
-  </div>
-
- <%# or param status is  passed with template %>
-
+  <%# to enable dropdown bootstrap %>
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
+  <%end%>
 
 </div>
-
-<%end%>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,22 +1,26 @@
 <div class="container col-11 my-4">
   <%= render "order_show" %>
+</div>
 
   <%# Bottom button(s) %>
+  <%# For order yet to be delivered  %>
   <% if @order.status != "delivered" %>
-    <div class="row">
-      <%= render "order_mark_delivered" %>
+    <div class="row d-flex justify-content-center">
       <div class="col-6">
-        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "btn btn-ghost btn-order-mark"%>
+        <%= render "order_mark_delivered" %>
       </div>
-    </div>
-
-  <% else %>
-    <div class="row justify-content-center">
       <div class="col-6">
-        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "btn btn-ghost btn-order-mark"%>
+        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "btn push-btn-small"%>
+      </div>
+
+    </div>
+  <%# For delievered order  %>
+  <% else %>
+    <div class="row d-flex justify-content-center">
+      <div class="col-6">
+        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "btn push-btn-small"%>
       </div>
     </div>
 
   <% end %>
 <%# container div below %>
-</div>


### PR DESCRIPTION
- Added dropdown for order status replacing separate buttons (+ popper.js before bootstrap.js for the specific pages) 
- Added 'view-btn' component for the button that isn't clickable (_view-btn.scss)
- Made partial htmls (_order_status_dropdown, _order_status_dropdown_supplier, _order_show) to refactor index and show html pages

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [] rails console
- [x] local server
- [ ] heroku
