### PR TITLE
bug fix to show template names

### DIFF
--- a/app/views/orders/_template_accordion.html.erb
+++ b/app/views/orders/_template_accordion.html.erb
@@ -6,7 +6,7 @@
       <button class="accordion-button collapsed px-0" id="accordion-button-order" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse<%= index + 1 %>" aria-expanded="false" aria-controls="flush-collapse<%= index + 1 %>">
         <div class="accordion-order" style="padding-right: 5px">
           <div class="accordion-order-info">
-            <strong><%= template.supplier.name %></strong><br>
+            <strong><%= template.name %></strong><br>
           </div>
         </div>
       </button>


### PR DESCRIPTION
# Description

bug fix to show template names:
<img width="1440" alt="Screenshot 2022-11-28 at 4 20 42 PM" src="https://user-images.githubusercontent.com/108777684/204228189-3407ebe8-079e-430b-8720-40e3d08417f8.png">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] rails console
- [x] local server
- [ ] heroku
