### PR TITLE
fixing nav bar

### DIFF
--- a/app/views/shared/_navbar2.html.erb
+++ b/app/views/shared/_navbar2.html.erb
@@ -5,6 +5,7 @@
       <%= link_to 'Suppliers', suppliers_path %>
       <%= link_to 'Templates', templates_path %>
       <%= link_to 'Orders', orders_path %>
+      <%= link_to 'Inventories', inventories_path %>
       <%= button_to "Logout", destroy_user_session_path, {method: :delete, class: "btn-logout"} %>
       <% else %>
       <div class="accordion accordion-flush" id="accordionFlushExample">


### PR DESCRIPTION
Inventory line was removed by mistake in navbar. Putting this back

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [x ] local server
- [ ] heroku
