### PR TITLE
Added cloudinary to Heroku production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
# Description

I have changed the setting in config/environments/production.rb to allow cloudinary to be used on heroku

"config.active_storage.service = :cloudinary"

I have also sent the cloudinary key to heroku, for when the change goes live.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [X] local server
- [ ] heroku
