### PR TITLE
Improved html behind email sent to suppliers

### DIFF
--- a/app/mailers/supplier_mailer.rb
+++ b/app/mailers/supplier_mailer.rb
@@ -5,6 +5,6 @@ class SupplierMailer < ApplicationMailer
     @supplier = params[:supplier]
     @order = params[:order]
     @user = params[:user]
-    mail(to: @supplier.email, subject: "Order for #{@user.email}")
+    mail(to: @supplier.email, subject: "Order from #{@user.email}")
   end
 end

--- a/app/views/supplier_mailer/order_email.html.erb
+++ b/app/views/supplier_mailer/order_email.html.erb
@@ -1,19 +1,106 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  </head>
-  <body>
-    <p>Dear Person-in-charge of <%= @supplier.name %></p>
-    <p>I'd like to order the following items for <%= @order.delivery_date %></p>
-    <p>to <%= @order.delivery_address.address %></p>
-    <ul>
-      <% @order.order_details.each do |order_detail| %>
-        <li><p><%= order_detail.product.name %> X <%= order_detail.quantity %></p></li>
-        <% end %>
-    </ul>
-    <p><%= @order.comments %> Thank you!</p>
+<style type="text/css">
+  body,
+  html,
+  .body {
+    background: #F3F3F3 !important;
+  }
+<div class = "container body" >
 
-    <p>Regards, <%= @user.email %></p>
-  </body>
-</html>
+      </style>
+            <h1>We have just sent you an order!</h1>
+
+      <p>
+          <strong>Order ID</strong><br/>
+          <%= @order.id %>
+      </p>
+
+      <div class="col-12 py-2">
+          <table class="table-order">
+            <thead>
+              <tr class="table-order-row">
+                <th style="text-align: left;" class="bold">Item</th>
+                <th>Price</th>
+                <th>Qty</th>
+                <th>Subtotal</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% total = 0 %>
+              <% @order.order_details.each do |order_detail|%>
+                <% product_id = order_detail.product_id %>
+                  <tr class="table-order-row my-2">
+                    <td style="text-align: left;"><%= order_detail.product.name %></td>
+                    <td><%= number_to_currency(order_detail.product.price) %></td>
+                    <td><%= order_detail.quantity %></td>
+                      <% price = order_detail.product.price %>
+                      <% quantity = order_detail.quantity %>
+                    <td><%= number_to_currency(price * quantity) %></td>
+                    <% total = total + price * quantity%>
+                  </tr>
+              <% end %>
+            </tbody>
+            <tfoot>
+              <tr class="table-order-row">
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td style="text-align: right"><strong>Total</strong></td>
+                <td><%= number_to_currency(total) %></td>
+              <tr>
+            </tfoot>
+          </table>
+        </div>
+
+        <%# Note to supplier  %>
+        <div class="row mt-4">
+          <div class="col-lg-6">
+            <strong>Note to supplier</strong><br/>
+            <%= @order.comments %><br/><br/>
+          </div>
+        </div>
+      </div>
+
+
+      <container>
+        <spacer size="16"></spacer>
+        <row>
+          <columns>
+
+            <spacer size="16"></spacer>
+            <callout class="secondary">
+              <row>
+              <columns large="6">
+                  <p>
+                    <strong>Shipping Address</strong><br/>
+                    <%= @order.delivery_address.address %>
+                  </p>
+                </columns>
+                <columns large="6">
+                  <p>
+                    <strong>Payment Method</strong><br/>
+                    Normal credit terms
+                  </p>
+                </columns>
+              </row>
+            </callout>
+
+
+
+        <row class="footer text-center">
+          <columns large="3">
+            <img src="http://placehold.it/170x30" alt="">
+          </columns>
+          <columns large="3">
+            <p>
+              Call us at 800.555.1923<br/>
+              Email us at support@srimble.io
+            </p>
+          </columns>
+          <columns large="3">
+            <p>
+              123 Maple Rd<br/>
+              Singapore, 95112
+            </p>
+          </columns>
+        </row>
+      </container>
+</div>

--- a/app/views/supplier_mailer/order_email_template_example.html.erb
+++ b/app/views/supplier_mailer/order_email_template_example.html.erb
@@ -1,0 +1,73 @@
+<style type="text/css">
+  body,
+  html,
+  .body {
+    background: #F3F3F3 !important;
+  }
+</style>
+<container>
+  <spacer size="16"></spacer>
+  <row>
+    <columns>
+      <h1>We have just sent you an order!</h1>
+      <p>We seek to create a strong network of supplier and are grateful for your timely delivery.</p>
+      <spacer size="16"></spacer>
+      <callout class="secondary">
+        <row>
+          <columns large="6">
+            <p>
+              <strong>Payment Method</strong><br/>
+              Dubloons
+            </p>
+            <p>
+              <strong>Email Address</strong><br/>
+              purchaser@srimble.io
+            </p>
+            <p>
+              <strong>Order ID</strong><br/>
+              <%= order_detail.order_id %>
+            </p>
+          </columns>
+          <columns large="6">
+            <p>
+              <strong>Shipping Address</strong><br/>
+              <%= @order.delivery_address %>
+            </p>
+          </columns>
+        </row>
+      </callout>
+      <h4>Order Details</h4>
+
+<% @order.order_details.each do |order_detail| %>
+   X <%= order_detail.quantity %>
+<% end %>
+
+      <table>
+        <tr><th>Item</th><th>Price</th></tr>
+        <% @order.order_details.each do |order_detail| %>
+          <tr><td><%= order_detail.product %></td><td><%= order_detail.quantity %></td></tr>
+        <% end %>
+      </table>
+      <hr/>
+      <h4>What's Next?</h4>
+      <p>Please deliver to us on: <%=@order.delivery_date%></p>
+    </columns>
+  </row>
+  <row class="footer text-center">
+    <columns large="3">
+      <img src="http://placehold.it/170x30" alt="">
+    </columns>
+    <columns large="3">
+      <p>
+        Call us at 800.555.1923<br/>
+        Email us at support@srimble.io
+      </p>
+    </columns>
+    <columns large="3">
+      <p>
+        123 Maple Rd<br/>
+        Singapore, 95112
+      </p>
+    </columns>
+  </row>
+</container> (edited)


### PR DESCRIPTION
# Description

Made changes to the email sent to suppliers with consistent css from the main website (orders page). 
The email now contains a total of the price payable to the supplier for all goods ordered.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [x] local server
- [ ] heroku
