### PR TITLE
removed syntax error on display

### DIFF
--- a/app/views/orders/_templates_index.html.erb
+++ b/app/views/orders/_templates_index.html.erb
@@ -20,7 +20,7 @@
         <span><%= link_to "+ New Template", new_supplier_order_path(@supplier.id), class: "push-btn-small create_order_btn", style: "position: absolute; margin-top: 30px; margin-left: 10px;" %></span>
       </div>
         <%# End of Accordion %>
-\
+
   <%# to enable dropdown bootstrap %>
       <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
   <%# for /templates without supplier id%>


### PR DESCRIPTION
# Description

removed syntax error - displays orders

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [ ] local server
- [ ] heroku
