### PR TITLE
Making btns look consistent

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -30,10 +30,11 @@
   margin-bottom: 20px;
   background-color: rgb(222, 223, 229);
   max-width: 600px;
-  padding: 5px;
+  padding: 7px;
   border-radius: 5px;
   justify-content: center;
   font-size: 14px;
+  border: 1px solid black;
 }
 
 .order-form-inputs label {

--- a/app/assets/stylesheets/pages/_orders.scss
+++ b/app/assets/stylesheets/pages/_orders.scss
@@ -111,7 +111,7 @@
 
 .container-order-show {
   background-color: rgb(222, 223, 229);
-  // border: 1px solid #003459;
+  border: 1px solid black;
   padding: 10px;
   margin: 0px;
   border-radius: 5px;

--- a/app/assets/stylesheets/pages/_suppliers.scss
+++ b/app/assets/stylesheets/pages/_suppliers.scss
@@ -65,6 +65,7 @@
   padding: 10px;
   margin: 0px;
   border-radius: 5px;
+  border: 2px solid black;
 }
 .supplier_templates_orders {
   display: flex;

--- a/app/views/orders/_new_order.html.erb
+++ b/app/views/orders/_new_order.html.erb
@@ -26,10 +26,10 @@
 
               <div data-order-form-target="add_detail" style="margin-top: -20px;" align="center">
                 <%= link_to '#', data: { action: "click->order-form#add_association"}, :style=>'text-decoration: none;' do %>
-              <div class="push-btn-small">Add more + </div>
+              <div class="push-btn-small" style="width: 85%">Add more + </div>
               <% end %>
             </div>
-<br>
+        <br>
             </div>
 
           <%= f.input :comments , label_html: {class: "order-form-add"}, input_html: {id: "order-form-select"}%>
@@ -37,11 +37,19 @@
             <span><strong>Grand Total</strong></span><br>
             <p id="grandtotal" >0</p>
           </div>
-          <div class="submit-container">
-            <!-- Button trigger modal -->
-            <button type="button" class="push-btn order-submit" data-bs-toggle="modal" data-bs-target="#exampleModal">
-              Save as Template
-            </button>
+
+          <%# Two bottom buttons  %>
+
+          <div class="row d-flex justify-content-center">
+            <div class="col-6">
+              <!-- Button trigger modal -->
+              <%# <button type="button" class="push-btn order-submit" data-bs-toggle="modal" data-bs-target="#exampleModal"> %>
+              <button type="button" class="push-btn-small" style="margin-top: 30px; width: 44%; margin-left: 1px;" data-bs-toggle="modal" data-bs-target="#exampleModal">
+                Save as Template
+              </button>
+            </div>
+
+            <div class="col-6">
             <!-- Modal -->
             <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
               <div class="modal-dialog">
@@ -60,8 +68,11 @@
                 </div>
               </div>
             </div>
-            <%= f.button :submit, "Submit", :class => "push-btn order-submit"%>
+            <%# <%= f.button :submit, "Submit", :class => "push-btn order-submit" %>
+            <%= f.button :submit, "Submit", :class => "push-btn-small", :style => "margin-top: 30px; width: 44%" %>
           </div>
+        </div>
+
         </div>
         <% end %>
       </div>

--- a/app/views/orders/_new_order_with_template.html.erb
+++ b/app/views/orders/_new_order_with_template.html.erb
@@ -27,7 +27,7 @@
 
               <div data-order-form-target="add_detail" style="margin-top: -20px;" align="center">
                 <%= link_to '#', data: { action: "click->order-form#add_association"}, :style=>'text-decoration: none;' do %>
-              <div class="push-btn-small">Add more + </div>
+              <div class="push-btn-small" style="width: 85%">Add more + </div>
               <% end %>
             </div>
             <br>
@@ -38,31 +38,39 @@
             <span><strong>Grand Total</strong></span><br>
             <span id="grandtotal" >0</span>
           </div>
-          <div class="submit-container">
+
+
+          <div class="row d-flex justify-content-center">
+            <div class="col-6">
             <!-- Button trigger modal -->
-            <button type="button" class="push-btn order-submit" data-bs-toggle="modal" data-bs-target="#exampleModal">
-              Save as Template
-            </button>
-            <!-- Modal -->
-            <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-              <div class="modal-dialog">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <h1 class="modal-title fs-5" id="exampleModalLabel">Add a name for this template</h1>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                  </div>
-                  <div class="modal-body">
-                    <%= f.input :name %>
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="push-btn order-submit" data-bs-dismiss="modal">Close</button>
-                    <%= button_to "Save", templates_path, class: "push-btn order-submit" %>
+              <button type="button" class="push-btn-small" style="margin-top: 30px; width: 44%; margin-left: 1px;" data-bs-toggle="modal" data-bs-target="#exampleModal">
+                Save as Template
+              </button>
+            </div>
+
+            <div class="col-6">
+              <!-- Modal -->
+              <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h1 class="modal-title fs-5" id="exampleModalLabel">Add a name for this template</h1>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                      <%= f.input :name %>
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="push-btn order-submit" data-bs-dismiss="modal">Close</button>
+                      <%= button_to "Save", templates_path, class: "push-btn order-submit" %>
+                    </div>
                   </div>
                 </div>
               </div>
+              <%= f.button :submit, "Submit", :class => "push-btn-small", :style => "margin-top: 30px; width: 44%" %>
             </div>
-            <%= f.button :submit, "Submit", :class => "push-btn order-submit"%>
           </div>
+
         </div>
         <% end %>
       </div>

--- a/app/views/orders/_templates_index.html.erb
+++ b/app/views/orders/_templates_index.html.erb
@@ -18,6 +18,7 @@
 
       <div class="templates_and_create mt-4">
         <span><%= link_to "+ New Template", new_supplier_order_path(@supplier.id), class: "push-btn-small create_order_btn", style: "position: absolute; margin-top: 30px; margin-left: 10px;" %></span>
+        <%# <span><%= link_to "+ New Template", new_supplier_order_path(@supplier.id), class: "btn btn-action-link", style: "position: absolute; margin-top: 30px; margin-left: 10px;" %>
       </div>
         <%# End of Accordion %>
 

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -23,7 +23,7 @@
     <div class="row d-flex justify-content-center">
       <div class="col-6">
 
-        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "btn-action-link btn" %>
+        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "push-btn-small" %>
       </div>
     </div>
   <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -9,12 +9,12 @@
     <div class="row d-flex justify-content-center">
       <div class="col-6">
       <!-- Button trigger modal -->
-        <button type="button" class="btn-action btn" data-bs-toggle="modal" data-bs-target="#markdeliveredModal">
+        <button type="button" class="push-btn-small" data-bs-toggle="modal" data-bs-target="#markdeliveredModal">
         Mark as Delivered
         </button>
       </div>
       <div class="col-6">
-        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "btn-action-link btn" %>
+        <%= link_to "Contact Supplier", supplier_path(@order.supplier_id), class: "push-btn-small" %>
       </div>
     </div>
 

--- a/app/views/suppliers/show.html.erb
+++ b/app/views/suppliers/show.html.erb
@@ -11,12 +11,12 @@
 <br>
    <div class="row d-flex justify-content-center">
       <div class="col-6">
-        <%# <%= link_to "Create an Order", supplier_templates_path(@supplier.id), class: "push-btn-small" %>
-        <%= link_to "Create an Order", supplier_templates_path(@supplier.id), class: "btn-action-link btn" %>
+        <%= link_to "Create an Order", supplier_templates_path(@supplier.id), class: "push-btn-small" %>
+        <%# <%= link_to "Create an Order", supplier_templates_path(@supplier.id), class: "btn-action-link btn" %>
       </div>
       <div class="col-6">
-        <%# <%= link_to "View Past Orders", supplier_orders_path(@supplier.id), class: "push-btn-small" %>
-        <%= link_to "View Past Orders", supplier_orders_path(@supplier.id), class: "btn-action-link btn" %>
+        <%= link_to "View Past Orders", supplier_orders_path(@supplier.id), class: "push-btn-small" %>
+        <%# <%= link_to "View Past Orders", supplier_orders_path(@supplier.id), class: "btn-action-link btn" %>
       </div>
   </div>
 </div>


### PR DESCRIPTION
Btn styling changes to look them consistent across order/template new , order/supplier/product show pages 

<img width="287" alt="image" src="https://user-images.githubusercontent.com/114599711/205540079-a225b9f3-9030-4291-ab08-5f05648e277d.png">


- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [ x] local server
- [ ] heroku
